### PR TITLE
allow index period to cross calendar year

### DIFF
--- a/BayesCalls2_10.R
+++ b/BayesCalls2_10.R
@@ -125,22 +125,42 @@ Nyrs = max(YearN)
 Moon = 2*dat$Illu-1
 # identify peak times, and Create index to Temporal matrix for peak times
 pk = numeric(length=length(DayOfYear))
-if (peaktimes_ref == 1){
-  ii = which(DayOfYear>=peakdates_strt & DayOfYear<=peakdates_end & 
-               c(TimeStepN - SunsetTimeStepN)>=peaktimes_strt/TimeStepIntvl &
-               c(TimeStepN - SunsetTimeStepN)<=peaktimes_stop/TimeStepIntvl)
-}else if (peaktimes_ref == 2){ 
-  ii = which(DayOfYear>=peakdates_strt & DayOfYear<=peakdates_end & 
-               c(TimeStepN-SunriseTimeStepN)>=peaktimes_strt/TimeStepIntvl &
-               c(TimeStepN-SunriseTimeStepN)<=peaktimes_stop/TimeStepIntvl)
-}else if (peaktimes_ref == 3){
-  ii1 = which(DayOfYear>=peakdates_strt & DayOfYear<=peakdates_end & 
-                c(TimeStepN - SunsetTimeStepN)>=peaktimes_strt/TimeStepIntvl &
-                c(TimeStepN - SunsetTimeStepN)<=peaktimes_stop/TimeStepIntvl)
-  ii2 = which(DayOfYear>=peakdates_strt & DayOfYear<=peakdates_end & 
-                c(TimeStepN-SunriseTimeStepN)>=peaktimes_strt2/TimeStepIntvl &
-                c(TimeStepN-SunriseTimeStepN)<=peaktimes_stop2/TimeStepIntvl)    
-  ii = c(ii1,ii2)
+if (calendar_pk_opt == 1) {
+  if (peaktimes_ref == 1){
+    ii = which(DayOfYear>=peakdates_strt & DayOfYear<=peakdates_end & 
+                 c(TimeStepN - SunsetTimeStepN)>=peaktimes_strt/TimeStepIntvl &
+                 c(TimeStepN - SunsetTimeStepN)<=peaktimes_stop/TimeStepIntvl)
+  }else if (peaktimes_ref == 2){ 
+    ii = which(DayOfYear>=peakdates_strt & DayOfYear<=peakdates_end & 
+                 c(TimeStepN-SunriseTimeStepN)>=peaktimes_strt/TimeStepIntvl &
+                 c(TimeStepN-SunriseTimeStepN)<=peaktimes_stop/TimeStepIntvl)
+  }else if (peaktimes_ref == 3){
+    ii1 = which(DayOfYear>=peakdates_strt & DayOfYear<=peakdates_end & 
+                  c(TimeStepN - SunsetTimeStepN)>=peaktimes_strt/TimeStepIntvl &
+                  c(TimeStepN - SunsetTimeStepN)<=peaktimes_stop/TimeStepIntvl)
+    ii2 = which(DayOfYear>=peakdates_strt & DayOfYear<=peakdates_end & 
+                  c(TimeStepN-SunriseTimeStepN)>=peaktimes_strt2/TimeStepIntvl &
+                  c(TimeStepN-SunriseTimeStepN)<=peaktimes_stop2/TimeStepIntvl)    
+    ii = c(ii1,ii2)
+  }
+} else if (calendar_pk_opt == 2) {
+  if (peaktimes_ref == 1){
+    ii = which((DayOfYear>=peakdates_strt | DayOfYear<=peakdates_end) & 
+                 c(TimeStepN - SunsetTimeStepN)>=peaktimes_strt/TimeStepIntvl &
+                 c(TimeStepN - SunsetTimeStepN)<=peaktimes_stop/TimeStepIntvl)
+  }else if (peaktimes_ref == 2){ 
+    ii = which((DayOfYear>=peakdates_strt | DayOfYear<=peakdates_end) & 
+                 c(TimeStepN-SunriseTimeStepN)>=peaktimes_strt/TimeStepIntvl &
+                 c(TimeStepN-SunriseTimeStepN)<=peaktimes_stop/TimeStepIntvl)
+  }else if (peaktimes_ref == 3){
+    ii1 = which((DayOfYear>=peakdates_strt | DayOfYear<=peakdates_end) & 
+                  c(TimeStepN - SunsetTimeStepN)>=peaktimes_strt/TimeStepIntvl &
+                  c(TimeStepN - SunsetTimeStepN)<=peaktimes_stop/TimeStepIntvl)
+    ii2 = which((DayOfYear>=peakdates_strt | DayOfYear<=peakdates_end) & 
+                  c(TimeStepN-SunriseTimeStepN)>=peaktimes_strt2/TimeStepIntvl &
+                  c(TimeStepN-SunriseTimeStepN)<=peaktimes_stop2/TimeStepIntvl)    
+    ii = c(ii1,ii2)
+  }
 }
 pk[ii] = 1
 Temppeak = matrix(data=0,nrow = NWeeks, ncol = NTsteps)

--- a/RunBC_2_10_generic.R
+++ b/RunBC_2_10_generic.R
@@ -58,10 +58,12 @@ if (Yearfocal==2017) {
 if (Species=='WTSH') {
   peakdates_strt = 50
   if (Yearfocal==2016) { peakdates_end = 109 } else { peakdates_end = 109 }
+  calendar_pk_opt = 1 # 1 = all in one year, 2 = peak spans new year
 } else if (Species=='BLNO') {
-  # still unclear when noddies are most active
-  peakdates_strt = 1
-  peakdates_end = 46
+  # use wide "index" period to capture any peak
+  if (Yearfocal==2017) { peakdates_strt = 345 } else { peakdates_strt = 344 } # Dec 10
+  if (Yearfocal==2016) { peakdates_end = 121 } else { peakdates_end = 120 } # April 30
+  calendar_pk_opt = 2 # 1 = all in one year, 2 = peak spans new year
 }
 
 # DayOfYear_strt =  70  # Day of Year (integer) to start reading data
@@ -74,8 +76,9 @@ if (Species=='WTSH') {
   peaktimes_stop =  -60  # Peak time boundary 2, always > than boundary1 (minutes relative to event) 
   peaktimes_ref =  2  # Reference event: 1 = after sunset, 2 = before sunrise, 3 = sunrise AND sunset 
 } else if (Species=='BLNO') {
-  peaktimes_strt =  -30  # Peak time boundary 1, minutes relative to a reference event (sunrise or sunset)
-  peaktimes_stop =  30  # Peak time boundary 2, always > than boundary1 (minutes relative to event) 
+  # use two hours to capture any peak
+  peaktimes_strt =  -60  # Peak time boundary 1, minutes relative to a reference event (sunrise or sunset)
+  peaktimes_stop =  60  # Peak time boundary 2, always > than boundary1 (minutes relative to event) 
   peaktimes_ref =  2  # Reference event: 1 = after sunset, 2 = before sunrise, 3 = sunrise AND sunset 
 }
 


### PR DESCRIPTION
When widening the index period to encompass peaks we have seen in BLNO activity in all years, there was a bug when it crossed the calendar year. This fixes that. Please take a look, Tim, and make sure you agree with the edits. I tested it and it seems fine, running it fully right now.